### PR TITLE
Allow Custom Filename Input/Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Alpha, the Omega compiler, is written with JavaScript and utilizes rustc for the
 
 You'll need two things installed in order to work with Omega: Node, and rustc.
 
-At the current stage, the filename to be compiled is hardcoded in the Omega compiler, so you'll need to change the name in the code manually. When you're ready to compile, simply run `node alpha.js`, and Alpha will tokenize your Omega file, parse it, convert it to valid Rust code, and then compile it to an executable. Once that's done, Alpha automatically cleans up the leftover files that were generated during Rust's compilation step.
+When you're ready to compile, simply run `node alpha.js <omega_file.o> <output_program.exe>`, and Alpha will tokenize your Omega file, parse it, convert it to valid Rust code, and then compile it to an executable. Once that's done, Alpha automatically cleans up the leftover files that were generated during Rust's compilation step.
 
 ## A Brief Introduction
 

--- a/compiler/alpha.js
+++ b/compiler/alpha.js
@@ -1,16 +1,26 @@
-const fs = require('fs');
-const { exec } = require('child_process');
-const tokenize = require('./tokenizer');
-const parse = require('./parser');
-const codegen = require('./codegen');
-
-const omegaFilename = "hello_world.o";
+const fs = require("fs");
+const { exec } = require("child_process");
+const tokenize = require("./tokenizer");
+const parse = require("./parser");
+const codegen = require("./codegen");
 const rustFilename = "hello_world.rs";
-const executableName = "hello_world.exe";
+const omega_input_filepattern = /^.*\.o$/i;
+const omega_output_file = process.argv[3];
+const omega_input_filename = process.argv[2];
 
-fs.readFile(omegaFilename, "utf8", (err, data) => {
+if (!omega_input_filepattern.test(omega_input_filename)) {
+  console.error("Omega input filename unrecognized");
+  return;
+}
+
+if (!omega_output_file) {
+  console.error("Omega output filename unrecognized");
+  return;
+}
+
+fs.readFile(omega_input_filename, "utf8", (err, data) => {
   if (err) {
-    console.error(`Error reading file ${omegaFilename}: ${err}`);
+    console.error(`Error reading file ${omega_input_filename}: ${err}`);
     return;
   }
 
@@ -25,28 +35,30 @@ fs.readFile(omegaFilename, "utf8", (err, data) => {
         return;
       }
 
-      exec(`rustc ${rustFilename} -o ${executableName}`, (err, stdout, stderr) => {
-        if (err) {
-          console.error(`Compilation error: ${err}`);
-          return;
-        }
-        if (stderr) {
-          console.error(`Compiler stderr: ${stderr}`);
-          return;
-        }
-        
-        fs.unlink(rustFilename, (err) => {
-          if (err) console.error(`Error deleting Rust source file: ${err}`);
-          else console.log(`${rustFilename} deleted successfully.`);
-        });
-        
-        const pdbFilename = executableName.replace('.exe', '.pdb');
-        fs.unlink(pdbFilename, (err) => {
-          if (!err) console.log(`${pdbFilename} deleted successfully.`);
-        });
+      exec(
+        `rustc ${rustFilename} -o ${omega_output_file}`,
+        (err, stdout, stderr) => {
+          if (err) {
+            console.error(`Compilation error: ${err}`);
+            return;
+          }
+          if (stderr) {
+            console.error(`Compiler stderr: ${stderr}`);
+            return;
+          }
 
-        console.log(`Compiled successfully to ${executableName}`);
-      });
+          fs.unlink(rustFilename, (err) => {
+            if (err) console.error(`Error deleting Rust source file: ${err}`);
+          });
+
+          const pdbFilename = omega_output_file.replace(".exe", ".pdb");
+          fs.unlink(pdbFilename, (err) => {
+            if (!err) console.log(`${pdbFilename} deleted successfully.`);
+          });
+
+          console.log(`Compiled successfully to ${omega_output_file}`);
+        }
+      );
     });
   } catch (error) {
     console.error(error);

--- a/compiler/hello_world.o
+++ b/compiler/hello_world.o
@@ -1,0 +1,3 @@
+fn main(): void {
+  out("Hello, world!");
+}

--- a/omegalang.com/docs/getting-started.md
+++ b/omegalang.com/docs/getting-started.md
@@ -30,9 +30,9 @@ fn main(): void {
 To compile your Omega program, run:
 
 ```bash
-node alpha.js
+node alpha.js <omega_file.o> <output_program.exe>
 ```
 
 _Please note that at the time of writing, the name of the Omega file that's compiled is hardcoded in the compiler itself. If you'd like to change the file name, you'll need to modify the compiler._
 
-This will compile it into an executable named `hello_world.exe`. Run the executable to see "Hello, world!" printed to the console.
+This will compile it into an executable. Run the executable to see "Hello, world!" printed to the console.


### PR DESCRIPTION
This change allows users to run `node alpha.js <input.o> <output.exe>` so they're not locked in to a particular platform or a hardcoded filename.